### PR TITLE
Update output directory in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
 			jinjaBootData: true,
 			lucideIcons: true,
 			buildConfig: {
+				outDir: "../<app-name>/public/frontend",
 				indexHtmlPath: "../<app-name>/www/frontend.html",
 				emptyOutDir: true,
 				sourcemap: true,


### PR DESCRIPTION
This PR fixes an issue where running npm run build for a Frappe UI app created with a custom name places the build assets in the wrong directory.

The Problem
When you create a new app using bench add-frappe-ui <custom-name>, the build assets are incorrectly generated in the /public/frontend directory instead of the expected /public/<custom-name> directory.

The Solution
This change updates the build configuration to ensure that the output directory correctly uses the custom name provided during app creation. Now, the build assets will be placed in the /public/<custom-name> folder, aligning the output path with the app's identity.

This pull request makes a configuration update to the Vite build process. The output directory for built frontend assets is now explicitly set, ensuring that the generated files are placed in the correct location for deployment.

Build configuration update:

* Set the `outDir` in the Vite `buildConfig` to `../<app-name>/public/frontend` to control where the frontend assets are output after building.