### PR TITLE
fix: path issue frappe UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,2 +1,2 @@
 @import "./assets/Inter/inter.css";
-@import "frappe-ui/src/style.css";
+@import "frappe-ui/style.css";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,4 @@
-import frappeUIPreset from "frappe-ui/src/tailwind/preset"
+import frappeUIPreset from "frappe-ui/tailwind"
 
 export default {
 	presets: [frappeUIPreset],


### PR DESCRIPTION
The paths in  (frappe-ui/src/style.css and frappe-ui/src/tailwind/preset) are not exposed directly. Instead, they are exposed as frappe-ui/style.css and frappe-ui/tailwind.

updated index.css and tailwind.config.js with correct path. 


"./tailwind": {
      "import": "./src/tailwind/preset.js",
      "default": "./src/tailwind/preset.js"
    },
    
"./style.css": {
      "import": "./src/style.css"
},
   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated framework integration paths to align with the latest package structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->